### PR TITLE
#10, #11 - Enable use with Sites, resolve issues with Get & Enforced flag

### DIFF
--- a/DSCClassResources/GPLink/GPLink.psd1
+++ b/DSCClassResources/GPLink/GPLink.psd1
@@ -4,7 +4,7 @@
     RootModule = 'GPLink.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.0.1'
+    ModuleVersion = '1.0.2'
     
     # ID used to uniquely identify this module
     GUID = 'aea171a9-72ee-4905-a318-b74a06ceab0a'


### PR DESCRIPTION
Resolves https://github.com/citadelgroup/GroupPolicyDsc/issues/10 and https://github.com/citadelgroup/GroupPolicyDsc/issues/11:
 - Replaces Get-ADObjectInheritance calls with Get-ADObject calls, allowing GPLink resource to link to AD Sites (https://github.com/citadelgroup/GroupPolicyDsc/issues/11)
 - Resolves exceptions thrown by Get-DscConfiguration when using GPLink resources
 - Resolves GPLink issue where LinkEnabled and Enforced do not get appropriately changed on policies