### PR TITLE
#13 - GPRegistryValue - distinguish policies 'Not Configured' and 'Disabled' policies fix 'Absent' behaviour

### DIFF
--- a/DSCClassResources/GPRegistryValue/GPRegistryValue.psd1
+++ b/DSCClassResources/GPRegistryValue/GPRegistryValue.psd1
@@ -4,7 +4,7 @@
     RootModule = 'GPRegistryValue.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.0.0'
+    ModuleVersion = '1.0.1'
     
     # ID used to uniquely identify this module
     GUID = '3eab30a8-5871-4520-91d9-1997c176273b'

--- a/Examples/Sample_CreateNewGPRegistryValue.ps1
+++ b/Examples/Sample_CreateNewGPRegistryValue.ps1
@@ -18,6 +18,7 @@ Configuration Sample_CreateNewGPRegistryValue {
             ValueName = "MySetting"
             ValueType = "DWord"
             Value = "1"
+            PolicyState = "Set"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Provides a mechanism to set Registry Values within Group Policy objects.
 * **[String] Name** _(Key)_: The registry key value name you want to configure.
 * **[String] ValueType** _(Write)_: The type of the registry value you want to configure. { DWord | Other }
 * **[String] Value** _(Write)_: The value of the registry you want to configure.
-* **[String] Ensure** _(Write)_: Specifies whether the Group Policy object should be present or absent. { *Present* | Absent }
+* **[String] PolicyState** _(Write)_: Whether to enable or disable the registry-based policy setting. { *Set* | Delete }
+* **[String] Ensure** _(Write)_: Specifies whether the registry value should be present (enabled/disabled) or absent (not configured). { *Present* | Absent }
 
 #### Read-Only Properties from Get-TargetResource
 


### PR DESCRIPTION
Resolves #13 - At present GPRegistryValue cannot distinguish between 'Disabled' and 'Not Configured' policies.

This adds a new 'PolicySet' key (values 'Set' and 'Delete') to allow policies to be 'Enabled' or 'Disabled'. Using 'Ensure' = 'Absent' removes the registry entry completely (with the result that the setting is 'Not Configured').

This permits configuration utilizing the following PowerShell cmdlets:
Set-GPRegistryValue -Disable
*and*
Remove-GPRegistryValue