### PR TITLE
#15 - All module cmdlets use Primary Domain Controller emulator by default, update to use next-nearest DC

### DIFF
--- a/DSCClassResources/GPPermission/GPPermission.psm1
+++ b/DSCClassResources/GPPermission/GPPermission.psm1
@@ -44,28 +44,32 @@ class GPPermission
     [Ensure] $Ensure = [Ensure]::Present
 
     [GPPermission] Get() {
-        $gppermissions = Get-GPPermission -Name $this.GPOName -All
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
+        $gppermissions = Get-GPPermission -Name $this.GPOName -Server $NextClosestSiteDC -All
 
         if($gppermissions.Trustee -contains $this.TargetName) {
-            $this.PermissionLevel = (Get-GPPermission -Name $this.GPOName -TargetName $this.TargetName -TargetType $this.TargetType).Permission
+            $this.PermissionLevel = (Get-GPPermission -Name $this.GPOName -TargetName $this.TargetName -TargetType $this.TargetType -Server $NextClosestSiteDC).Permission
         }
 
         return $this
     }
   
     [void] Set() {
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
         if($this.Ensure -eq [Ensure]::Present) {
             if($this.Force -eq [Force]::No) {
                 Set-GPPermission -Name $this.GPOName `
                                  -TargetName $this.TargetName `
                                  -TargetType $this.TargetType `
-                                 -PermissionLevel ($this.PermissionLevel).ToString()
+                                 -PermissionLevel ($this.PermissionLevel).ToString() `
+                                 -Server $NextClosestSiteDC
             }
             else {
                 Set-GPPermission -Name $this.GPOName `
                                 -TargetName $this.TargetName `
                                 -TargetType $this.TargetType `
                                 -PermissionLevel ($this.PermissionLevel).ToString() `
+                                -Server $NextClosestSiteDC `
                                 -Replace
             }
         }
@@ -74,12 +78,14 @@ class GPPermission
                              -TargetName $this.TargetName `
                              -TargetType $this.TargetType `
                              -PermissionLevel ([PermissionLevel]::None).ToString() `
+                             -Server $NextClosestSiteDC `
                              -Replace
         }
     }
 
     [bool] Test() {
-        $gppermissions = Get-GPPermission -Name $this.GPOName -All
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
+        $gppermissions = Get-GPPermission -Name $this.GPOName -Server $NextClosestSiteDC -All
 
         if($this.Ensure -eq [Ensure]::Present) {
             if($gppermissions.Trustee.Name -contains ($this.TargetName).Split('\')[1]) {

--- a/DSCClassResources/GPRegistryValue/GPRegistryValue.psm1
+++ b/DSCClassResources/GPRegistryValue/GPRegistryValue.psm1
@@ -26,9 +26,11 @@ class GPRegistryValue
     [Ensure] $Ensure = [Ensure]::Present
 
     [GPRegistryValue] Get() {
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
         $currentvalue = Get-GPRegistryValue -Name $this.Name `
                                      -Key $this.Key `
                                      -ValueName $this.ValueName `
+                                     -Server $NextClosestSiteDC `
                                      -ErrorAction SilentlyContinue
 
         if($null -ne $currentvalue) {
@@ -44,20 +46,23 @@ class GPRegistryValue
     }
   
     [void] Set() {
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
         if($this.Ensure -eq [Ensure]::Present) {
             if($this.ValueType -eq "DWord") {
                 Set-GPRegistryValue -Name $this.Name `
                                     -Key $this.Key `
                                     -ValueName $this.ValueName `
                                     -Value ([Int32]::Parse($this.Value)) `
-                                    -Type $this.ValueType
+                                    -Type $this.ValueType `
+                                    -Server $NextClosestSiteDC
             }
             else {
                 Set-GPRegistryValue -Name $this.Name `
                                     -Key $this.Key `
                                     -ValueName $this.ValueName `
                                     -Value $this.Value `
-                                    -Type $this.ValueType
+                                    -Type $this.ValueType `
+                                    -Server $NextClosestSiteDC
             }
         }
         else {
@@ -65,14 +70,17 @@ class GPRegistryValue
                                 -Key $this.Key `
                                 -ValueName $this.ValueName `
                                 -Value $this.Value `
+                                -Server $NextClosestSiteDC `
                                 -Disable
         }
     }
 
     [bool] Test() {
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
         $currentvalue = Get-GPRegistryValue -Name $this.Name `
                                      -Key $this.Key `
                                      -ValueName $this.ValueName `
+                                     -Server $NextClosestSiteDC `
                                      -ErrorAction SilentlyContinue
 
         if($this.Ensure -eq [Ensure]::Present) {

--- a/DSCClassResources/GroupPolicy/GroupPolicy.psm1
+++ b/DSCClassResources/GroupPolicy/GroupPolicy.psm1
@@ -18,7 +18,8 @@ class GroupPolicy
     [Ensure] $Ensure = [Ensure]::Present
 
     [GroupPolicy] Get() {
-        $policy = Get-GPO -Name $this.Name -ErrorAction SilentlyContinue
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
+        $policy = Get-GPO -Name $this.Name -Server $NextClosestSiteDC -ErrorAction SilentlyContinue
 
         if($null -ne $policy) {
             $this.Status = $policy.GpoStatus
@@ -32,22 +33,24 @@ class GroupPolicy
     }
   
     [void] Set() {
-        $policy = Get-GPO -Name $this.Name -ErrorAction SilentlyContinue
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
+        $policy = Get-GPO -Name $this.Name -Server $NextClosestSiteDC -ErrorAction SilentlyContinue
 
         if($this.Ensure -eq [Ensure]::Present) {
             if($null -eq $policy) {
-                $policy = New-GPO -Name $this.Name
+                $policy = New-GPO -Name $this.Name -Server $NextClosestSiteDC
             }
 
             $policy.GpoStatus = $this.Status
         }
         else {
-            Remove-GPO -Name $this.Name
+            Remove-GPO -Name $this.Name -Server $NextClosestSiteDC
         }
     }
 
     [bool] Test() {
-        $policy = Get-GPO -Name $this.Name -ErrorAction SilentlyContinue
+        $NextClosestSiteDC = (Get-ADDomainController -Discover -NextClosestSite).HostName.Value
+        $policy = Get-GPO -Name $this.Name -Server $NextClosestSiteDC -ErrorAction SilentlyContinue
 
         if($this.Ensure -eq [Ensure]::Present) {
             if($null -eq $policy) {

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ None
 
 ## Versions
 
+### 1.0.4 (Waiting for release)
+
+* All modules discover and connect to the next nearest domain controller rather than the Primary Domain Controller (PDC) emulator.
+
 ### 1.0.0
 
 * Initial release of GroupPolicyDsc.


### PR DESCRIPTION
Resolves #15 - All of the cmdlets in the GroupPolicy PowerShell module connect to the Primary Domain Controller (PDC) emulator by default, which can cause a lot of unnecessary network traffic and slowdowns when using this module in a global environment.

https://learn.microsoft.com/en-us/powershell/module/grouppolicy/?view=windowsserver2022-ps

This can be fixed using the -Server parameter for each module to point to the next nearest Domain Controller. I will submit a pull request shortly fixing this.